### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/alexis/collection/collection.rkt
+++ b/alexis/collection/collection.rkt
@@ -10,7 +10,6 @@
          racket/generator
          racket/function
          racket/match
-         unstable/function
          alexis/util/match
          alexis/util/renamed
          (prefix-in
@@ -22,7 +21,7 @@
               racket/stream
               racket/dict))
          (prefix-in
-          u: unstable/list)
+          u: racket/list)
          "countable.rkt"
          "private/util.rkt")
 

--- a/alexis/collection/contract.rkt
+++ b/alexis/collection/contract.rkt
@@ -4,7 +4,7 @@
   alexis/collection/collection
   racket/contract
   racket/generic
-  unstable/function
+  racket/function
   racket/stream
   racket/set)
 

--- a/alexis/collection/indexable.rkt
+++ b/alexis/collection/indexable.rkt
@@ -2,7 +2,6 @@
 
 (require racket/generic
          racket/function
-         unstable/function
          racket/dict
          "collection.rkt")
 

--- a/info.rkt
+++ b/info.rkt
@@ -7,7 +7,6 @@
 
 (define deps
   '("base"
-    "unstable-list-lib"
     "rackunit-lib"
     "alexis-util"))
 (define build-deps


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-list-lib` package, as it will not be part of the main distribution in future versions.
